### PR TITLE
add memory optimization for training

### DIFF
--- a/fluid/mnist.py
+++ b/fluid/mnist.py
@@ -128,6 +128,8 @@ def run_benchmark(model, args):
         learning_rate=0.001, beta1=0.9, beta2=0.999)
     opt.minimize(avg_cost)
 
+    fluid.memory_optimize(fluid.default_main_program())
+
     # Initialize executor
     place = fluid.CPUPlace() if args.device == 'CPU' else fluid.CUDAPlace(0)
     exe = fluid.Executor(place)

--- a/fluid/resnet50.py
+++ b/fluid/resnet50.py
@@ -190,6 +190,8 @@ def run_benchmark(model, args):
     opts = optimizer.minimize(avg_cost)
     accuracy = fluid.evaluator.Accuracy(input=predict, label=label)
 
+    fluid.memory_optimize(fluid.default_main_program())
+
     train_reader = paddle.batch(
         paddle.reader.shuffle(
             paddle.dataset.cifar.train10()

--- a/fluid/vgg16.py
+++ b/fluid/vgg16.py
@@ -104,6 +104,8 @@ def main():
     optimizer = fluid.optimizer.Adam(learning_rate=args.learning_rate)
     opts = optimizer.minimize(avg_cost)
 
+    fluid.memory_optimize(fluid.default_main_program())
+
     # Initialize executor
     place = core.CPUPlace() if args.device == 'CPU' else core.CUDAPlace(0)
     exe = fluid.Executor(place)


### PR DESCRIPTION
Have tested  in CPU based on latest develop branch Paddle code.

- **mnist**
```
FLAGS_do_memory_benchmark=true GLOG_vmodule=executor=2 GLOG_logtostderr=1 python mnist.py --device=CPU --batch_size=128 --iterations=2 --pass_num=1
```
maximum memory usage: 50622464 --> 43061248

- **vgg16**
```
FLAGS_do_memory_benchmark=true GLOG_vmodule=executor=2 GLOG_logtostderr=1 python vgg16.py --device=CPU --batch_size=128
```
maximum memory usage: 1729540096 --> 1132953600

- **resnet50**

```
FLAGS_do_memory_benchmark=true GLOG_vmodule=executor=2 GLOG_logtostderr=1 python resnet50.py --device=CPU --batch_size=128 --model=resnet_cifar10 --data_set=cifar10
```

maximum memory usage: 1275125760 --> 663941120