### PR TITLE
optimize RNN

### DIFF
--- a/fluid/machine_translation.py
+++ b/fluid/machine_translation.py
@@ -258,13 +258,9 @@ def train():
 
     fluid.memory_optimize(fluid.default_main_program())
 
-    # train_batch_generator = paddle.batch(
-    #     paddle.reader.shuffle(
-    #         paddle.dataset.wmt14.train(args.dict_size), buf_size=1000),
-    #     batch_size=args.batch_size)
-
     train_batch_generator = paddle.batch(
-            paddle.dataset.wmt14.train(args.dict_size),
+        paddle.reader.shuffle(
+            paddle.dataset.wmt14.train(args.dict_size), buf_size=1000),
         batch_size=args.batch_size)
 
     test_batch_generator = paddle.batch(

--- a/fluid/machine_translation.py
+++ b/fluid/machine_translation.py
@@ -256,9 +256,15 @@ def train():
     optimizer = fluid.optimizer.Adam(learning_rate=args.learning_rate)
     optimizer.minimize(avg_cost)
 
+    fluid.memory_optimize(fluid.default_main_program())
+
+    # train_batch_generator = paddle.batch(
+    #     paddle.reader.shuffle(
+    #         paddle.dataset.wmt14.train(args.dict_size), buf_size=1000),
+    #     batch_size=args.batch_size)
+
     train_batch_generator = paddle.batch(
-        paddle.reader.shuffle(
-            paddle.dataset.wmt14.train(args.dict_size), buf_size=1000),
+            paddle.dataset.wmt14.train(args.dict_size),
         batch_size=args.batch_size)
 
     test_batch_generator = paddle.batch(

--- a/fluid/stacked_dynamic_lstm.py
+++ b/fluid/stacked_dynamic_lstm.py
@@ -125,6 +125,8 @@ def main():
     adam = fluid.optimizer.Adam()
     adam.minimize(loss)
 
+    fluid.memory_optimize(fluid.default_main_program())
+
     place = fluid.CPUPlace() if args.device == 'CPU' else fluid.CUDAPlace(0)
     exe = fluid.Executor(place)
     exe.run(fluid.default_startup_program())


### PR DESCRIPTION
The optimization result for the first batch training(**please remove shuffle of training data to get the accurate testing result**) is following:

| policy          | memory usage     | 
|--------------- | --------- |
|without any optimization| 5728446208 bytes|
|delete step scope| 1126832384 bytes|
|with memory reuse policy |1115982080 bytes|

Command:
```
FLAGS_benchmark=true GLOG_vmodule=executor=2 GLOG_logtostderr=0 GLOG_log_dir="./" python machine_translation.py
```